### PR TITLE
wlan_logging_sock_svc: ignore fatal event 4105

### DIFF
--- a/drivers/staging/prima/CORE/SVC/src/logging/wlan_logging_sock_svc.c
+++ b/drivers/staging/prima/CORE/SVC/src/logging/wlan_logging_sock_svc.c
@@ -1935,7 +1935,7 @@ void wlan_process_done_indication(uint8 type, uint32 reason_code)
 
 	if ((type == WLAN_FW_LOGS) && reason_code &&
 				 vos_isFatalEventEnabled() &&
-				 vos_is_wlan_logging_enabled())
+				 vos_is_wlan_logging_enabled() && reason_code != 4105)
 	{
 		if(wlan_is_log_report_in_progress() == TRUE)
 		{


### PR DESCRIPTION
Fixes dmesg spam and battery drain for me. It would be better to fix the actual issue though

The same problem occurs when using 3.18 kernels so its not a bug specific to 4.9